### PR TITLE
Fix bug that impeded loading a game on Windows (errno)

### DIFF
--- a/modules/ctrl/src/start.c
+++ b/modules/ctrl/src/start.c
@@ -108,6 +108,8 @@ static	void	start_load	(void)
 	/* size & game init (sets errno) */
 	int	rows;
 	int	cols;
+
+	errno	= 0;
 	game_init_load(&rows, &cols);
 
 	if (!errno) {


### PR DESCRIPTION
errno is set to 0 before calling the function that sets its value.
Before that, on Windows, residual values of errno impeded loading a game.